### PR TITLE
エラー時の終了コードの変更

### DIFF
--- a/parser00.c
+++ b/parser00.c
@@ -25,19 +25,19 @@ int getToken(void) {
 
 void parse_error(char *error_message) {
   printf ("parse error: %s\n", error_message);
-  exit(0);
+  exit(EXIT_FAILURE);
 }
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
     printf ("argument error\n");
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   yyin = fopen(argv[1], "r"); /* ファイルを開く処理 */
   if (yyin  == NULL) {
     printf ("%s file not found.\n", argv[1]);
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   /* 最初に1トークン読み込んでおく */

--- a/parser01.c
+++ b/parser01.c
@@ -25,19 +25,19 @@ int getToken(void) {
 
 void parse_error(char *error_message) {
   printf ("parse error: %s\n", error_message);
-  exit(0);
+  exit(EXIT_FAILURE);
 }
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
     printf ("argument error\n");
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   yyin = fopen(argv[1], "r"); /* ファイルを開く処理 */
   if (yyin  == NULL) {
     printf ("%s file not found.\n", argv[1]);
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   /* 最初に1トークン読み込んでおく */

--- a/parser02.c
+++ b/parser02.c
@@ -7,19 +7,19 @@ extern FILE *yyin;      /* 読み込むソースファイル */
 int main(int argc, char *argv[]) {
   if (argc != 2) {
     printf ("argument error\n");
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   yyin = fopen(argv[1], "r");
   if (yyin  == NULL) {
     printf ("%s file not found.\n", argv[1]);
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   /* 構文解析スタート */
   if (yyparse() != 0) {
 	 printf("parse error\n");
-	 exit(0);
+	 exit(EXIT_FAILURE);
   } else {
 	printf("parse success\n");
   }	

--- a/parser10.c
+++ b/parser10.c
@@ -57,19 +57,19 @@ int getToken(void) { /* トークンを取得する関数 */
 void pl0parse_error(char *error_message) { /* 構文エラーを出す関数 */
   printf("parse error near line %d(%s): %s\n",
          line_number, yytext, error_message);
-  exit(0);
+  exit(EXIT_FAILURE);
 }
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
     printf ("argument error\n");
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   yyin = fopen(argv[1], "r");
   if (yyin  == NULL) {
     printf ("%s file not found.\n", argv[1]);
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   /* 構文解析スタート */


### PR DESCRIPTION
`Exit(0);`はmain関数の`return 0;`と同義であり正常終了を示すため、エラー時は0以外の値を返し、異常終了であることを示すべき。
